### PR TITLE
Implements a frame work to test and submit a large number of different configurations

### DIFF
--- a/Tools/batches/generic.py
+++ b/Tools/batches/generic.py
@@ -1,0 +1,31 @@
+#This is an example fragment. Code like this will be imported by submitBatch.py in order to make the jobs that will be run
+
+
+def makeJobs(submitJob,saveJSON,options,workdir):
+
+
+   #This is a simple example, it will test a simple MLP with a single hidden layer with a variable number of nodes
+   
+   options.netOp.convLayers = []
+   options.netOp.rnnLayers = 0
+
+   options.netOp.networkName = "Simple MLP"
+   options.confName = "Simple MLP"
+   options.runOp.runName = "Simple MLP"
+
+   options.netOp.denseLayers = [50]
+
+   if workdir[-1] != "/": workdir += "/"
+
+   saveJSON(options,workdir+"generic.json")
+
+   for x in [x for x in range(20,500) if x % 50 == 0]:
+      for y in [y for y in range(20,min(x,200)) if y % 40 == 0]:
+         for z in [z for z in range(15,min(y,100)) if z % 30 == 0]:
+            options.netOp.denseLayers = [x,y,z]
+            options.netOp.networkName = "Simple MLP: "+str(x)+", "+str(y)+", "+str(z)
+            options.netOp.runName = "Simple MLP: "+str(x)+", "+str(y)+", "+str(z)
+            options.confName = "Simple MLP: "+str(x)+", "+str(y)+", "+str(z)
+   
+            options.cleanUp()
+            submitJob(options,workdir, "simpleMLP_"+str(x)+"_"+str(y)+"_"+str(z))

--- a/Tools/batches/test.py
+++ b/Tools/batches/test.py
@@ -1,0 +1,32 @@
+#This is an example fragment. Code like this will be imported by submitBatch.py in order to make the jobs that will be run
+
+
+def makeJobs(submitJob,saveJSON,options,workdir):
+
+
+   #This is simple test code
+   
+   options.netOp.convLayers = []
+   options.netOp.rnnLayers = 0
+   
+   options.runOp.nepoch = 2
+
+   options.confName = "Batch Job test"
+
+   options.netOp.denseLayers = [50]
+
+   options.netOp.loadStandardVariables("TeamAlpha1DConv")
+
+   options.cleanUp()
+
+   if workdir[-1] != "/": workdir += "/"
+
+   saveJSON(options,workdir+"test.json")
+
+   for x in [20,40,60]:
+      options.netOp.denseLayers = [x]
+      options.netOp.networkName = "Test MLP: "+str(x)
+      options.confName = "Test MLP: "+str(x)
+  
+      options.cleanUp()
+      submitJob(options,workdir, "testMLP_"+str(x))

--- a/Tools/python/Validation.py
+++ b/Tools/python/Validation.py
@@ -40,7 +40,7 @@ parser.add_option ('-c', "--disc", dest='discCut', action='store', default=0.6, 
 parser.add_option ('-k', "--sklrf", dest='sklrf', action='store_true', help="Use skl random forest instead of tensorflow")
 parser.add_option ('-x', "--xgboost", dest='xgboost', action='store_true', help="Run using xgboost")
 parser.add_option ('-a', "--mvaFile", dest='mvaFile', action='store', default="", help="Mva training file")
-parser.add_option ('-f', "--dataFilePath",      dest="dataFilePath",      action='store',      default="data",                     help="Path where the input datafiles are stored (default: \"data\")")
+parser.add_option ('-f', "--dataFilePath",      dest="dataFilePath",      action='store',                     help="Path where the input datafiles are stored (default: \"data\")")
 parser.add_option ('-d', "--directory", dest='directory', action='store', default="", help="Directory to store outputs")
 parser.add_option ('-v', "--variables", dest='variables', action='store', help="Input features to use")
 parser.add_option ('-m', "--modelCfg",          dest="modelJSON",         action='store',      help="JSON with model definitions")
@@ -154,12 +154,14 @@ varsname = dg.getList()
 #dataTTbarAll = pd.read_pickle("trainingTuple_division_1_TTbarSingleLep_validation_jpt20_nocone.pkl.gz")
 #dataTTbarAll = pd.read_pickle("trainingTuple_division_1_TTbarSingleLep_validation_100k.pkl.gz")
 
+if options.dataFilePath != None: trainingOptions.runOp.dataPath = options.dataFilePath
+
 if options.sklrf:
-    dataTTbarName = options.dataFilePath + "/trainingTuple_division_1_TTbarSingleLep_validation_100K_0.h5"
+    dataTTbarName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_TTbarSingleLep_validation_100K_0.h5"
 elif options.xgboost:
-    dataTTbarName = options.dataFilePath + "/trainingTuple_division_1_TTbarSingleLep_validation.pkl.gz"
+    dataTTbarName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_TTbarSingleLep_validation.pkl.gz"
 else:
-    dataTTbarName = options.dataFilePath + "/trainingTuple_division_1_TTbarSingleLep_validation_100K_0.h5"
+    dataTTbarName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_TTbarSingleLep_validation_100K_0.h5"
 
 if ".pkl" in dataTTbarName:
     dataTTbarAll = pd.read_pickle(dataTTbarName)
@@ -194,11 +196,11 @@ dataTTbarGen = dataTTbarGen[dataTTbarGen.Njet >= 4]
 
 #Training data for overfitting check
 if options.sklrf:
-    dataTTbarNameTrain = options.dataFilePath + "/trainingTuple_division_0_TTbarSingleLep_training_1M_0.h5"
+    dataTTbarNameTrain = trainingOptions.runOp.dataPath + "/trainingTuple_division_0_TTbarSingleLep_training_1M_0.h5"
 elif options.xgboost:
-    dataTTbarNameTrain = options.dataFilePath + "/trainingTuple_division_0_TTbarSingleLep_training.pkl.gz"
+    dataTTbarNameTrain = trainingOptions.runOp.dataPath + "/trainingTuple_division_0_TTbarSingleLep_training.pkl.gz"
 else:
-    dataTTbarNameTrain = options.dataFilePath + "/trainingTuple_division_0_TTbarSingleLep_training_1M_0.h5"
+    dataTTbarNameTrain = trainingOptions.runOp.dataPath + "/trainingTuple_division_0_TTbarSingleLep_training_1M_0.h5"
 
 import h5py
 f = h5py.File(dataTTbarNameTrain, "r")
@@ -347,11 +349,11 @@ plt.close()
 print "PROCESSING ZNUNU VALIDATION DATA"
 
 if options.sklrf:
-    dataZnunuName = options.dataFilePath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
+    dataZnunuName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
 elif options.xgboost:
-    dataZnunuName = options.dataFilePath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
+    dataZnunuName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
 else:
-    dataZnunuName = options.dataFilePath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
+    dataZnunuName = trainingOptions.runOp.dataPath + "/trainingTuple_division_1_ZJetsToNuNu_validation_700K_0.h5"
 
 if ".pkl" in dataZnunuName:
     dataZnunuAll = pd.read_pickle(dataZnunuName)

--- a/Tools/python/taggerOptions.py
+++ b/Tools/python/taggerOptions.py
@@ -200,6 +200,8 @@ class runOptions:
 
    #configuration variables can be left in an inconsistent state, this method will make them consistent again
    def cleanUp(self):
+      if self.dataPath[-1] != "/": self.dataPath += "/"
+
       self.makeTrainingSamples()
       self.makeValidationSamples()
       return
@@ -385,6 +387,13 @@ class networkOptions:
 
       return parser    
 
+   #This method will load standard variables
+   def loadStandardVariables(self, variables):
+      inputVariables, jetVariables = StandardVariables(variables)
+      self.inputVariables = inputVariables
+      self.jetVariables = jetVariables
+      self.cleanUp()
+
    #This methods will take options provided by the parser, and if it is not the default value, it will what is currently saved
    def override(self, cloptions):
 
@@ -498,6 +507,11 @@ class taggerOptions:
 
       return parser
 
+   def cleanUp(self):
+      #This will return runOp and netOp to consistent states
+      self.runOp.cleanUp()
+      self.netOp.cleanUp()
+
    def override(self, cloptions):
    
        #The override methods will return a string with info that will be saved in the info list.
@@ -509,6 +523,8 @@ class taggerOptions:
       if not isinstance(self, taggerOptions):
          print "Trying to convert non taggerOptions object with serializeTaggerOptions"
          return
+
+      self.cleanUp()
 
       output = dict(self.__dict__) #The dictionary returned points to the attributes of this object and manipulating the dictionary will change this object. We need to make a copy so that this doesn't happen
       output["runOp"] = dict(self.runOp.__dict__) #This assumes a simple structure for runOp, this needs to be rewritten is that assumtion is violated
@@ -527,6 +543,8 @@ def saveOptionsToJSON(options,fname):
    if not isinstance(options, taggerOptions):
       print "Incorrect object passed. saveOptionsToJSON works on taggerOptions objects. Nothing will be saved."
       return
+
+   options.cleanUp()
 
    try:
       f = open(fname,"w")


### PR DESCRIPTION
To use use the command "python python/submitBatch.py -d <directory> -m <fragment>"

This will create a directory structure rooted at <directory>
The fragment option points to some python code that will make the appropriate variations
Examples are batches/generic.py and batches/test.py

This framework functions by initializing and modifying a taggerOptions object

<fragment> must include a method named "makeJobs", it is passed a reference to the submitJob method, a reference to the saveJSON method, a refence to the taggerOptions object, and the workdirectory

Fragement will then follow its own logic to make changes to the taggerOptions object, then will pass the object and a job name to the submitJob method.
It will do this for each job to be submitted.