### PR TITLE
Submit batch bug fix

### DIFF
--- a/Tools/python/submitBatch.py
+++ b/Tools/python/submitBatch.py
@@ -88,8 +88,8 @@ class SubmitJobs:
             fname = "%s/batchJob%i.pbs"%(self.workdir, i)
             with open(fname, "w") as f:
                for job in jobs:
-                  print job["shName"]
                   if job != None:
+                     print job["shName"]
                      f.write("bash %s &\n"%(job["shName"]))
                f.write("wait\n")
             #submit the job


### PR DESCRIPTION
Symptom: Error arose when submitting an odd number of jobs (5).
Small bug fix: Only print a job if a job exists (job is not None).
