### PR TITLE
Make Downloaded Files Read Only

### DIFF
--- a/TopTagger/scripts/getTaggerCfg.sh
+++ b/TopTagger/scripts/getTaggerCfg.sh
@@ -232,7 +232,8 @@ then
 fi
 
 # make all files in DOWNLOAD_DIR read only
-chmod uog-w *
+# a (all) = ugo (user group others)
+chmod a-w *
 
 cd $STARTING_DIR
 

--- a/TopTagger/scripts/getTaggerCfg.sh
+++ b/TopTagger/scripts/getTaggerCfg.sh
@@ -231,6 +231,9 @@ then
     fi
 fi
 
+# make all files in DOWNLOAD_DIR read only
+chmod uog-w *
+
 cd $STARTING_DIR
 
 if [[ ! -z $VERBOSE ]] # True if VERBOSE is set
@@ -259,5 +262,4 @@ then
         done
     fi
 fi
-
 


### PR DESCRIPTION
For getTaggerCfg.sh script:
- Make all downloaded files in DOWNLOAD_DIR read only