### PR TITLE
Add support for environment variable expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ Icon
 
 ##Github Python Ignore
 *.py[cod]
+**/__init__.py
 
 # C extensions
 *.so

--- a/TopTagger/interface/TopTaggerUtilities.h
+++ b/TopTagger/interface/TopTaggerUtilities.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <map>
+#include <string>
 
 class Constituent;
 class TopObject;
@@ -613,6 +614,10 @@ namespace ttUtility
 
     ///Helper function to get the direct decay products of the gen tops
     std::vector<const TLorentzVector*> GetTopdauLVec(const TLorentzVector& top, const std::vector<TLorentzVector>& genDecayLVec, const std::vector<int>& genDecayPdgIdVec, const std::vector<int>& genDecayIdxVec, const std::vector<int>& genDecayMomIdxVec);
+
+    //Helper function to expand env. variables in file path
+    //Originally from https://stackoverflow.com/questions/1902681/expand-file-names-that-have-environment-variables-in-their-path/20715800#20715800
+    void autoExpandEnvironmentVariables(std::string&);
 
 }
 

--- a/TopTagger/src/TTMTensorflow.cpp
+++ b/TopTagger/src/TTMTensorflow.cpp
@@ -254,7 +254,9 @@ void free_buffer(void* data, size_t length)
 
 TF_Buffer* TTMTensorflow::read_file(const std::string& file) 
 {
-    FILE *f = fopen(file.c_str(), "rb");
+    std::string fname=file;
+    ttUtility::autoExpandEnvironmentVariables(fname);
+    FILE *f = fopen(fname.c_str(), "rb");
 
     if(f == nullptr)
     {

--- a/TopTagger/src/TopTaggerUtilities.cpp
+++ b/TopTagger/src/TopTaggerUtilities.cpp
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <utility>
+#include <regex>
 
 namespace ttUtility
 {
@@ -1028,6 +1029,17 @@ namespace ttUtility
             }//top cand.
         }//gen loop
         return topdauLVec;
+    }
+
+    void autoExpandEnvironmentVariables(std::string& path)
+    {
+        static std::regex env("\\$\\{([^}]+)\\}");
+        std::smatch match;
+        while (std::regex_search(path, match, env)){
+            const char* s = getenv(match[1].str().c_str());
+            const std::string var(s == NULL ? "" : s);
+            path.replace(match[0].first, match[0].second, var);
+        }
     }
 
 }


### PR DESCRIPTION
This PR allows one to specify something like
    modelFile = "${CMSSW_BASE}/src/somedirs/somename.pb" (or some other environment variable)
inside the cfg file, also ignores _init_.py in .gitignore.

I avoided using edm::FileInPath in order to remain compatible with non-CMSSW compilation cases by introducing a simpler getenv wrapper that should serve the purpose.