### PR TITLE
Fix Overlap Removal

### DIFF
--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -12,14 +12,14 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     printf("List of used constituents:\n");
     for(const auto& usedConstituent : usedConsts)
     {
-        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M());
+        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
     }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
+            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,29 +8,11 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
-    bool verbose = false;
-    // loop over set of used constituents for testing
-    if (verbose)
-    {
-        printf("List of used constituents:\n");
-    }
-    for(const auto& usedConstituent : usedConsts)
-    {
-        if (verbose)
-        {
-            printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
-        }
-    }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            if (verbose)
-            {
-                printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
-                printf("In %s: return true\n", __func__);
-            }
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -68,10 +50,6 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    if (verbose)
-    {
-        printf("In %s: return false\n", __func__);
-    }
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,12 +8,18 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
+    // loop over set of used constituents for testing
+    printf("List of used constituents:\n");
+    for(const auto& usedConstituent : usedConsts)
+    {
+        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M());
+    }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: ((pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf))\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
+            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -77,7 +77,7 @@ void TTMFilterBase::markConstituentsUsed(const std::vector<const Constituent *>&
                 //If there is one or fewer subjets, instead match to the overall AK8 jet
                 for(const auto& matchConst : allConstituents) 
                 {
-                    if(matchConst->getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(constituent->p(), matchConst.p()) < dRMaxAK8)
+                    if(matchConst.getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(constituent->p(), matchConst.p()) < dRMaxAK8)
                     {
                         usedConstituents.insert(&matchConst);
                     }
@@ -89,7 +89,7 @@ void TTMFilterBase::markConstituentsUsed(const std::vector<const Constituent *>&
                 {
                     for(const auto& matchConst : allConstituents) 
                     {
-                        if(matchConst->getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(subjet.p(), matchConst.p()) < dRMax)
+                        if(matchConst.getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(subjet.p(), matchConst.p()) < dRMax)
                         {
                             usedConstituents.insert(&matchConst);
                         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,7 +13,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            //printf("In %s: return true 1\n", __func__);
+            printf("In %s: return true\n", __func__);
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -51,7 +51,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    //printf("In %s: return false 1\n", __func__);
+    printf("In %s: return false\n", __func__);
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,19 +8,29 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
+    bool verbose = false;
     // loop over set of used constituents for testing
-    printf("List of used constituents:\n");
+    if (verbose)
+    {
+        printf("List of used constituents:\n");
+    }
     for(const auto& usedConstituent : usedConsts)
     {
-        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
+        if (verbose)
+        {
+            printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
+        }
     }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
-            printf("In %s: return true\n", __func__);
+            if (verbose)
+            {
+                printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
+                printf("In %s: return true\n", __func__);
+            }
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -58,7 +68,10 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    printf("In %s: return false\n", __func__);
+    if (verbose)
+    {
+        printf("In %s: return false\n", __func__);
+    }
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,6 +13,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
+            printf("In %s: constituent already used: ((pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf))\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMNanoAODClusterAlgo.cpp
+++ b/TopTagger/src/TTMNanoAODClusterAlgo.cpp
@@ -48,6 +48,7 @@ void TTMNanoAODClusterAlgo::run(TopTaggerResults& ttResults)
             //Only use AK8 W here 
             if(passDeepAK8WReqs(constituents[i])) 
             {
+                printf("I found a W boson\n");
                 TopObject topCand({&constituents[i]}, TopObject::MERGED_W);
                 topCand.setDiscriminator(constituents[i].getWDisc());
 

--- a/TopTagger/src/TTMNanoAODClusterAlgo.cpp
+++ b/TopTagger/src/TTMNanoAODClusterAlgo.cpp
@@ -48,7 +48,6 @@ void TTMNanoAODClusterAlgo::run(TopTaggerResults& ttResults)
             //Only use AK8 W here 
             if(passDeepAK8WReqs(constituents[i])) 
             {
-                printf("I found a W boson\n");
                 TopObject topCand({&constituents[i]}, TopObject::MERGED_W);
                 topCand.setDiscriminator(constituents[i].getWDisc());
 

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,6 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
+            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
+            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
+            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {


### PR DESCRIPTION
Fix handling of overlap removal.

Require the following for getting used constituents:
```matchConst.getType() == Constituent::AK4JET ```