### PR TITLE
Fix Overlap Removal  (for master branch)

### DIFF
--- a/TopTagger/interface/TTMOverlapResolution.h
+++ b/TopTagger/interface/TTMOverlapResolution.h
@@ -27,7 +27,7 @@ private:
     TopObject::Type type_;
     std::string sortMethod_;
     std::function<bool (const TopObject* t1, const TopObject* t2)> sortFunc_;
-    bool doSort_, markUsed_;
+    bool doSort_, markUsed_, doOverlapRemoval_;
 
 public:
     void getParameters(const cfg::CfgDocument*, const std::string&);

--- a/TopTagger/src/TTMConstituentReqs.cpp
+++ b/TopTagger/src/TTMConstituentReqs.cpp
@@ -46,10 +46,10 @@ bool TTMConstituentReqs::passAK8WReqs(const Constituent& constituent) const
 
     double tau21 = constituent.getTau2()/constituent.getTau1();
 
-    return constituent.p().Pt() > minAK8WPt_ &&
-           constituent.getSoftDropMass() * constituent.getWMassCorr() > minAK8WMass_  && 
-           constituent.getSoftDropMass() * constituent.getWMassCorr() < maxAK8WMass_ &&
-           tau21 < maxWTau21_;
+    return float(constituent.p().Pt()) > minAK8WPt_ &&
+           float(constituent.getSoftDropMass()) * float(constituent.getWMassCorr()) > minAK8WMass_  && 
+           float(constituent.getSoftDropMass()) * float(constituent.getWMassCorr()) < maxAK8WMass_ &&
+           float(tau21) < maxWTau21_;
 }
 
 bool TTMConstituentReqs::passAK4WReqs(const Constituent& constituent, const Constituent& constituentAK8) const
@@ -75,10 +75,10 @@ bool TTMConstituentReqs::passAK8TopReqs(const Constituent& constituent) const
 
     double tau32 = constituent.getTau3()/constituent.getTau2();
 
-    return constituent.p().Pt() > minAK8TopPt_ &&
-           constituent.getSoftDropMass() > minAK8TopMass_  && 
-           constituent.getSoftDropMass() < maxAK8TopMass_ &&
-           tau32 < maxTopTau32_;
+    return float(constituent.p().Pt()) > minAK8TopPt_ &&
+           float(constituent.getSoftDropMass()) > minAK8TopMass_  && 
+           float(constituent.getSoftDropMass()) < maxAK8TopMass_ &&
+           float(tau32) < maxTopTau32_;
 }
 
 bool TTMConstituentReqs::passDeepAK8WReqs(const Constituent& constituent) const
@@ -86,10 +86,10 @@ bool TTMConstituentReqs::passDeepAK8WReqs(const Constituent& constituent) const
     //check that it is an AK8 jet
     if(constituent.getType() != Constituent::AK8JET) return false;
 
-    return constituent.p().Pt() > minAK8WPt_ &&
-           constituent.getSoftDropMass() > minAK8WMass_  && 
-           constituent.getSoftDropMass() < maxAK8WMass_ &&
-           constituent.getWDisc() > deepAK8WDisc_;
+    return float(constituent.p().Pt()) > minAK8WPt_ &&
+           float(constituent.getSoftDropMass()) > minAK8WMass_  && 
+           float(constituent.getSoftDropMass()) < maxAK8WMass_ &&
+           float(constituent.getWDisc()) > deepAK8WDisc_;
 }
 
 bool TTMConstituentReqs::passDeepAK8TopReqs(const Constituent& constituent) const
@@ -97,10 +97,10 @@ bool TTMConstituentReqs::passDeepAK8TopReqs(const Constituent& constituent) cons
     //check that it is an AK8 jet
     if(constituent.getType() != Constituent::AK8JET) return false;
 
-    return constituent.p().Pt() > minAK8TopPt_ &&
-           constituent.getSoftDropMass() > minAK8TopMass_  && 
-           constituent.getSoftDropMass() < maxAK8TopMass_ &&
-           constituent.getTopDisc() > deepAK8TopDisc_;
+    return float(constituent.p().Pt()) > minAK8TopPt_ &&
+           float(constituent.getSoftDropMass()) > minAK8TopMass_  && 
+           float(constituent.getSoftDropMass()) < maxAK8TopMass_ &&
+           float(constituent.getTopDisc()) > deepAK8TopDisc_;
 }
 
 bool TTMConstituentReqs::passAK4ResolvedReqs(const Constituent& constituent, const double minPt) const

--- a/TopTagger/src/TTMConstituentReqs.cpp
+++ b/TopTagger/src/TTMConstituentReqs.cpp
@@ -33,11 +33,6 @@ void TTMConstituentReqs::getParameters(const cfg::CfgDocument* cfgDoc, const std
     minAK8WPt_        = cfgDoc->get("minAK8WPt",        localCxt, -999.9);
     minAK4WPt_        = cfgDoc->get("minAK4WPt",        localCxt, -999.9);
     
-    // testing
-    std::cout << "In " << __func__ << ": minAK8WMass_ = " << minAK8WMass_ << std::endl;
-    std::cout << "In " << __func__ << ": maxAK8WMass_ = " << maxAK8WMass_ << std::endl;
-    std::cout << "In " << __func__ << ": minAK8TopMass_ = " << minAK8TopMass_ << std::endl;
-    std::cout << "In " << __func__ << ": maxAK8TopMass_ = " << maxAK8TopMass_ << std::endl;
     //trijet parameters
 }
 

--- a/TopTagger/src/TTMConstituentReqs.cpp
+++ b/TopTagger/src/TTMConstituentReqs.cpp
@@ -32,7 +32,12 @@ void TTMConstituentReqs::getParameters(const cfg::CfgDocument* cfgDoc, const std
     maxWTau21_        = cfgDoc->get("maxWTau21",        localCxt, -999.9);
     minAK8WPt_        = cfgDoc->get("minAK8WPt",        localCxt, -999.9);
     minAK4WPt_        = cfgDoc->get("minAK4WPt",        localCxt, -999.9);
-
+    
+    // testing
+    std::cout << "In " << __func__ << ": minAK8WMass_ = " << minAK8WMass_ << std::endl;
+    std::cout << "In " << __func__ << ": maxAK8WMass_ = " << maxAK8WMass_ << std::endl;
+    std::cout << "In " << __func__ << ": minAK8TopMass_ = " << minAK8TopMass_ << std::endl;
+    std::cout << "In " << __func__ << ": maxAK8TopMass_ = " << maxAK8TopMass_ << std::endl;
     //trijet parameters
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,45 +13,45 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: return true 1\n", __func__);
+            //printf("In %s: return true 1\n", __func__);
             return true;
         }
-        else if(constituent->getType() == Constituent::AK8JET)
-        {
-            //If the constituent is AK8 we will also check its subjets are not used
-            if(constituent->getSubjets().size() <= 1)
-            {
-                // If this jet has only one subjet, use matching to the overall AK8 jet instead 
-                for(const auto& usedConstituent : usedConsts)
-                {
-                    if(ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()) < dRMaxAK8)
-                    {
-                        //we found a match
-                        printf("In %s: return true 2; dR=%f, dRMaxAK8=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()), dRMaxAK8);
-                        return true;
-                    }
-                }
-            }
-            else
-            {
-                for(const auto& subjet : constituent->getSubjets())
-                {
-                    for(const auto& usedConstituent : usedConsts)
-                    {
-                        if(ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()) < dRMax)
-                        {
-                            //we found a match
-                            printf("In %s: return true 3; dR=%f, dRMax=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()), dRMax);
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
+        //else if(constituent->getType() == Constituent::AK8JET)
+        //{
+        //    //If the constituent is AK8 we will also check its subjets are not used
+        //    if(constituent->getSubjets().size() <= 1)
+        //    {
+        //        // If this jet has only one subjet, use matching to the overall AK8 jet instead 
+        //        for(const auto& usedConstituent : usedConsts)
+        //        {
+        //            if(ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()) < dRMaxAK8)
+        //            {
+        //                //we found a match
+        //                //printf("In %s: return true 2; dR=%f, dRMaxAK8=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()), dRMaxAK8);
+        //                return true;
+        //            }
+        //        }
+        //    }
+        //    else
+        //    {
+        //        for(const auto& subjet : constituent->getSubjets())
+        //        {
+        //            for(const auto& usedConstituent : usedConsts)
+        //            {
+        //                if(ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()) < dRMax)
+        //                {
+        //                    //we found a match
+        //                    //printf("In %s: return true 3; dR=%f, dRMax=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()), dRMax);
+        //                    return true;
+        //                }
+        //            }
+        //        }
+        //    }
+        //}
     }
 
     //if nothing is found then we have an unused jet
-    printf("In %s: return false 1\n", __func__);
+    //printf("In %s: return false 1\n", __func__);
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -12,14 +12,14 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     printf("List of used constituents:\n");
     for(const auto& usedConstituent : usedConsts)
     {
-        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M());
+        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
     }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
+            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,29 +8,11 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
-    bool verbose = false;
-    // loop over set of used constituents for testing
-    if (verbose)
-    {
-        printf("List of used constituents:\n");
-    }
-    for(const auto& usedConstituent : usedConsts)
-    {
-        if (verbose)
-        {
-            printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
-        }
-    }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            if (verbose)
-            {
-                printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
-                printf("In %s: return true\n", __func__);
-            }
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -68,10 +50,6 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    if (verbose)
-    {
-        printf("In %s: return false\n", __func__);
-    }
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,12 +8,18 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
+    // loop over set of used constituents for testing
+    printf("List of used constituents:\n");
+    for(const auto& usedConstituent : usedConsts)
+    {
+        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M());
+    }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: ((pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf))\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
+            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -41,7 +41,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
                         if(ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()) < dRMax)
                         {
                             //we found a match
-                            printf("In %s: return true 3; dR=%f, dRMaxAK8=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()), dRMax);
+                            printf("In %s: return true 3; dR=%f, dRMax=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()), dRMax);
                             return true;
                         }
                     }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -77,7 +77,7 @@ void TTMFilterBase::markConstituentsUsed(const std::vector<const Constituent *>&
                 //If there is one or fewer subjets, instead match to the overall AK8 jet
                 for(const auto& matchConst : allConstituents) 
                 {
-                    if(matchConst->getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(constituent->p(), matchConst.p()) < dRMaxAK8)
+                    if(matchConst.getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(constituent->p(), matchConst.p()) < dRMaxAK8)
                     {
                         usedConstituents.insert(&matchConst);
                     }
@@ -89,7 +89,7 @@ void TTMFilterBase::markConstituentsUsed(const std::vector<const Constituent *>&
                 {
                     for(const auto& matchConst : allConstituents) 
                     {
-                        if(matchConst->getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(subjet.p(), matchConst.p()) < dRMax)
+                        if(matchConst.getType() == Constituent::AK4JET && ROOT::Math::VectorUtil::DeltaR(subjet.p(), matchConst.p()) < dRMax)
                         {
                             usedConstituents.insert(&matchConst);
                         }

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,7 +13,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            //printf("In %s: return true 1\n", __func__);
+            printf("In %s: return true\n", __func__);
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -51,7 +51,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    //printf("In %s: return false 1\n", __func__);
+    printf("In %s: return false\n", __func__);
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,6 +13,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
+            printf("In %s: return true 1\n", __func__);
             return true;
         }
         else if(constituent->getType() == Constituent::AK8JET)
@@ -26,6 +27,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
                     if(ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()) < dRMaxAK8)
                     {
                         //we found a match
+                        printf("In %s: return true 2; dR=%f, dRMaxAK8=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(constituent->p(), usedConstituent->p()), dRMaxAK8);
                         return true;
                     }
                 }
@@ -39,6 +41,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
                         if(ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()) < dRMax)
                         {
                             //we found a match
+                            printf("In %s: return true 3; dR=%f, dRMaxAK8=%f\n", __func__, ROOT::Math::VectorUtil::DeltaR(subjet.p(), usedConstituent->p()), dRMax);
                             return true;
                         }
                     }
@@ -48,6 +51,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
+    printf("In %s: return false 1\n", __func__);
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -8,19 +8,29 @@
 
 bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& constituents, const std::set<const Constituent*>& usedConsts, const double dRMax, const double dRMaxAK8) const
 {
+    bool verbose = false;
     // loop over set of used constituents for testing
-    printf("List of used constituents:\n");
+    if (verbose)
+    {
+        printf("List of used constituents:\n");
+    }
     for(const auto& usedConstituent : usedConsts)
     {
-        printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
+        if (verbose)
+        {
+            printf(" - used constituent: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", usedConstituent->p().Pt(), usedConstituent->p().Eta(), usedConstituent->p().Phi(), usedConstituent->p().M(), usedConstituent->getType());
+        }
     }
     for(const auto& constituent : constituents)
     {
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
-            printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
-            printf("In %s: return true\n", __func__);
+            if (verbose)
+            {
+                printf("In %s: constituent already used: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M(), constituent->getType());
+                printf("In %s: return true\n", __func__);
+            }
             return true;
         }
         //else if(constituent->getType() == Constituent::AK8JET)
@@ -58,7 +68,10 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
     }
 
     //if nothing is found then we have an unused jet
-    printf("In %s: return false\n", __func__);
+    if (verbose)
+    {
+        printf("In %s: return false\n", __func__);
+    }
     return false;
 }
 

--- a/TopTagger/src/TTMFilterBase.cpp
+++ b/TopTagger/src/TTMFilterBase.cpp
@@ -13,6 +13,7 @@ bool TTMFilterBase::constituentsAreUsed(const std::vector<const Constituent*>& c
         if(usedConsts.count(constituent) > 0)
         {
             //First return true if constituent is found (this covers all AK4 and most AK8 jets)
+            printf("In %s: constituent already used: ((pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf))\n", __func__, constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi(), constituent->p().M());
             printf("In %s: return true\n", __func__);
             return true;
         }

--- a/TopTagger/src/TTMNanoAODClusterAlgo.cpp
+++ b/TopTagger/src/TTMNanoAODClusterAlgo.cpp
@@ -48,6 +48,7 @@ void TTMNanoAODClusterAlgo::run(TopTaggerResults& ttResults)
             //Only use AK8 W here 
             if(passDeepAK8WReqs(constituents[i])) 
             {
+                printf("I found a W boson\n");
                 TopObject topCand({&constituents[i]}, TopObject::MERGED_W);
                 topCand.setDiscriminator(constituents[i].getWDisc());
 

--- a/TopTagger/src/TTMNanoAODClusterAlgo.cpp
+++ b/TopTagger/src/TTMNanoAODClusterAlgo.cpp
@@ -48,7 +48,6 @@ void TTMNanoAODClusterAlgo::run(TopTaggerResults& ttResults)
             //Only use AK8 W here 
             if(passDeepAK8WReqs(constituents[i])) 
             {
-                printf("I found a W boson\n");
                 TopObject topCand({&constituents[i]}, TopObject::MERGED_W);
                 topCand.setDiscriminator(constituents[i].getWDisc());
 

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,6 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -149,7 +149,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-
+            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if(overlaps || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
+            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
+            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -16,15 +16,16 @@ void TTMOverlapResolution::getParameters(const cfg::CfgDocument* cfgDoc, const s
     cfg::Context commonCxt("Common");
     cfg::Context localCxt(localContextName);
 
-    mt_           = cfgDoc->get("mt",           commonCxt, -999.9);
-    maxTopEta_    = cfgDoc->get("maxTopEta",    commonCxt, -999.9);
-    dRMatch_      = cfgDoc->get("dRMatch",      commonCxt, -999.9);
-    dRMatchAK8_   = cfgDoc->get("dRMatchAK8",   commonCxt, 0.8);
+    mt_                 = cfgDoc->get("mt",                 commonCxt, -999.9);
+    maxTopEta_          = cfgDoc->get("maxTopEta",          commonCxt, -999.9);
+    dRMatch_            = cfgDoc->get("dRMatch",            commonCxt, -999.9);
+    dRMatchAK8_         = cfgDoc->get("dRMatchAK8",         commonCxt, 0.8);
 
-    cvsThreshold_  = cfgDoc->get("cvsThreshold",  localCxt,  -999.9);
-    type_          = static_cast<TopObject::Type>(cfgDoc->get("NConstituents", localCxt,  TopObject::ANY));
-    sortMethod_    = cfgDoc->get("sortMethod",    localCxt,  "EMPTY");
-    markUsed_      = cfgDoc->get("markUsed",      localCxt,  true);
+    cvsThreshold_       = cfgDoc->get("cvsThreshold",       localCxt,  -999.9);
+    type_               = static_cast<TopObject::Type>(cfgDoc->get("NConstituents", localCxt,  TopObject::ANY));
+    sortMethod_         = cfgDoc->get("sortMethod",         localCxt,  "EMPTY");
+    markUsed_           = cfgDoc->get("markUsed",           localCxt,  true);
+    doOverlapRemoval_   = cfgDoc->get("doOverlapRemoval",   localCxt,  true);
 
     //select the approperiate sorting function 
     doSort_ = true;  //sort true unless option "none" is selected
@@ -149,9 +150,9 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
+            //printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
             //Prune top from final top collection if it fails the following requirements
-            if(overlaps || !passTopEta)
+            if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {
                 //This is inefficient and dumb
                 iTop = tops.erase(iTop);

--- a/TopTagger/src/TTMOverlapResolution.cpp
+++ b/TopTagger/src/TTMOverlapResolution.cpp
@@ -150,7 +150,7 @@ void TTMOverlapResolution::run(TopTaggerResults& ttResults)
 
             //Check if the candidates have been used in another top
             bool overlaps = constituentsAreUsed(jets, usedJets, dRMatch_, dRMatchAK8_);
-            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f) overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), overlaps);
+            printf("In %s: top (pt=%f, eta=%f, phi=%f, mass=%f), type=%d, overlaps=%d\n", __func__, (*iTop)->p().Pt(), (*iTop)->p().Eta(), (*iTop)->p().Phi(), (*iTop)->p().M(), (*iTop)->getType(), overlaps);
             //Prune top from final top collection if it fails the following requirements
             if((doOverlapRemoval_ && overlaps) || !passTopEta)
             {


### PR DESCRIPTION
Fix handling of overlap removal.

Require the following for getting used constituents:
```matchConst.getType() == Constituent::AK4JET```